### PR TITLE
Fix safe string copy

### DIFF
--- a/src/common/CServerMap.cpp
+++ b/src/common/CServerMap.cpp
@@ -97,14 +97,14 @@ lpctstr CServerMapBlockingState::GetTileName( dword dwID )	// static
 	tchar * pStr = Str_GetTemp();
 	if ( dwID < TERRAIN_QTY )
 	{
-		const CUOTerrainInfo land( (TERRAIN_TYPE)dwID );
-		strncpy( pStr, land.m_name, Str_TempLength() );
+               const CUOTerrainInfo land( (TERRAIN_TYPE)dwID );
+               Str_CopyLimitNull(pStr, land.m_name, Str_TempLength());
 	}
 	else
 	{
-		dwID -= TERRAIN_QTY;
-		const CUOItemInfo item((ITEMID_TYPE)dwID);
-		strncpy( pStr, item.m_name, Str_TempLength());
+               dwID -= TERRAIN_QTY;
+               const CUOItemInfo item((ITEMID_TYPE)dwID);
+               Str_CopyLimitNull(pStr, item.m_name, Str_TempLength());
 	}
 	return pStr;
 }

--- a/src/game/CRegion.cpp
+++ b/src/game/CRegion.cpp
@@ -129,7 +129,7 @@ bool CRegion::MakeRegionDefname()
     lpctstr ptcKey = nullptr;	// auxiliary, the key of a similar CVarDef, if any found
     tchar * pbuf = Str_GetTemp();
     tchar * pszDef = pbuf + 2;
-    strncpy(pbuf, "a_", Str_TempLength());
+    Str_CopyLimitNull(pbuf, "a_", Str_TempLength());
 
     lpctstr pszName = GetName();
     GETNONWHITESPACE( pszName );

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -4656,7 +4656,7 @@ bool CChar::ShoveCharAtPosition(CPointMap const& ptDst, ushort *uiStaminaRequire
                 if ((g_Cfg.m_iRevealFlags & REVEALF_OSILIKEPERSONALSPACE))
                 {
                     // OSILIKEPERSONALSPACE flag block the reveal but DEFMSG_HIDING_STUMBLE_OSILIKE is send. To avoid it, simply use return 1 in @PERSONALSPACE
-                    strncpy(pszMsg, g_Cfg.GetDefaultMsg(DEFMSG_HIDING_STUMBLE_OSILIKE), Str_TempLength());
+                    Str_CopyLimitNull(pszMsg, g_Cfg.GetDefaultMsg(DEFMSG_HIDING_STUMBLE_OSILIKE), Str_TempLength());
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- replace `strncpy` calls copying into temp buffers with `Str_CopyLimitNull`

## Testing
- `clang++ -std=c++17 -fsyntax-only src/common/CServerMap.cpp src/game/CRegion.cpp src/game/chars/CCharAct.cpp` *(fails: unknown type name 'consteval')*

------
https://chatgpt.com/codex/tasks/task_e_6844a8cbd12c8320935ac4d84163f92b